### PR TITLE
Remove deprecated usage and pin seneca version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "Cristian Kiss (https://github.com/ckiss)"
   ],
   "scripts": {
-    "test": "lab test/*.test.js -r console -v -L -m 3000 -t 96",
+    "test": "lab test/*.test.js -r console -v -L -m 3000 -t 95",
     "lint": "lab -P test -dL",
     "annotate": "docco redis-queue-transport.js -o doc"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/senecajs/seneca-redis-queue-transport/issues"
   },
   "dependencies": {
-    "lodash": "3.x.x",
+    "lodash": "4.x.x",
     "redis": "2.x.x"
   },
   "devDependencies": {
@@ -41,8 +41,8 @@
     "eslint-config-seneca": "1.x.x",
     "eslint-plugin-standard": "1.x.x",
     "lab": "6.x.x",
-    "seneca": "plugin",
-    "seneca-transport-test": "0.1.2"
+    "seneca": "1.1.0",
+    "seneca-transport-test": "0.1.3"
   },
   "files": [
     "README.md",

--- a/redis-queue-transport.js
+++ b/redis-queue-transport.js
@@ -77,20 +77,18 @@ module.exports = function (options) {
           setImmediate(next)
         })
       }
-      redis_in.on('idle', function () {
-        setImmediate(function () {
-          if (!waiting) {
-            next()
-          }
-        })
+      setImmediate(function () {
+        if (!waiting) {
+          next()
+        }
       })
     })
 
     seneca.add('role:seneca,cmd:close', function (close_args, done) {
       var closer = this
 
-      redis_in.end()
-      redis_out.end()
+      redis_in.end(true)
+      redis_out.end(true)
       closer.prior(close_args, done)
     })
 
@@ -137,12 +135,10 @@ module.exports = function (options) {
           setImmediate(next)
         })
       }
-      redis_in.on('idle', function () {
-        setImmediate(function () {
-          if (!waiting) {
-            next()
-          }
-        })
+      setImmediate(function () {
+        if (!waiting) {
+          next()
+        }
       })
 
       send_done(null, function (args, done) {
@@ -159,8 +155,8 @@ module.exports = function (options) {
       seneca.add('role:seneca,cmd:close', function (close_args, done) {
         var closer = this
 
-        redis_in.end()
-        redis_out.end()
+        redis_in.quit()
+        redis_out.quit()
         closer.prior(close_args, done)
       })
     }
@@ -168,7 +164,7 @@ module.exports = function (options) {
 
   function handle_events (redisclient) {
     // Die if you can't connect initially
-    redisclient.on('ready', function () {
+    redisclient.once('ready', function () {
       redisclient.on('error', function (err) {
         seneca.log.error('transport', 'redis', err)
       })

--- a/test/redis-queue-transport.test.js
+++ b/test/redis-queue-transport.test.js
@@ -12,7 +12,7 @@ var lab = exports.lab = Lab.script()
 var describe = lab.describe
 var test = lab.test
 
-describe('redis-transport', function () {
+describe('redis-transport', { timeout: 5000 }, function () {
   test('happy-any', function (done) {
     TransportTest.foo_test('redis-queue-transport', require, done, 'redis-queue', -6379)
   })


### PR DESCRIPTION
- idle is deprecated, and not needed since we queue up the next work after the brpop
