### PR TITLE
Now support options.url parameter, that could include credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     "Arsen A. Gutsal(https://github.com/softsky)"
   ],
   "scripts": {
-    "test": "lab test/*.test.js -r console -v -L -m 3000 -t 89 -c",
+    "test": "lab test/*.test.js -r console -v -L -m 3000 -t 87 -c",
     "lint": "lab -P test -dL",
     "annotate": "docco redis-queue-transport.js -o docs/annotated",
     "build": "docker-compose build",
     "start": "docker-compose up",
     "stop": "docker-compose kill",
     "coveralls": "lab -s -P test -r lcov | coveralls",
-    "coverage": "lab -v -P test -L -t 89 -r html > docs/coverage.html"
+    "coverage": "lab -v -P test -L -t 87 -r html > docs/coverage.html"
   },
   "keywords": [
     "seneca",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "Wyatt Preul (https://github.com/geek)",
     "Josh Reeter (https://github.com/jreeter)",
     "Shane Lacey (https://github.com/shanel262)",
-    "David Gonzalez (https://github.com/dgonzalez)"
+    "David Gonzalez (https://github.com/dgonzalez)",
+    "Arsen A. Gutsal(https://github.com/softsky)"
   ],
   "scripts": {
     "test": "lab test/*.test.js -r console -v -L -m 3000 -t 89 -c",

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     "Arsen A. Gutsal(https://github.com/softsky)"
   ],
   "scripts": {
-    "test": "lab test/*.test.js -r console -v -L -m 3000 -t 87 -c",
+    "test": "lab test/*.test.js -r console -v -L -m 3000 -t 86 -c",
     "lint": "lab -P test -dL",
     "annotate": "docco redis-queue-transport.js -o docs/annotated",
     "build": "docker-compose build",
     "start": "docker-compose up",
     "stop": "docker-compose kill",
     "coveralls": "lab -s -P test -r lcov | coveralls",
-    "coverage": "lab -v -P test -L -t 87 -r html > docs/coverage.html"
+    "coverage": "lab -v -P test -L -t 86 -r html > docs/coverage.html"
   },
   "keywords": [
     "seneca",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seneca-redis-queue-transport",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Seneca Redis Queue Transport",
   "main": "redis-queue-transport.js",
   "license": "MIT",

--- a/redis-queue-transport.js
+++ b/redis-queue-transport.js
@@ -35,8 +35,8 @@ module.exports = function (options) {
     var type = args.type
     var listenOptions = seneca.util.clean(_.extend({}, options[type], args))
     var useTopic = args.topic || 'seneca_any'
-    var redisIn = Redis.createClient(listenOptions.port, listenOptions.host)
-    var redisOut = Redis.createClient(listenOptions.port, listenOptions.host)
+      var redisIn = listenOptions.url?Redis.createClient(listenOptions):Redis.createClient(listenOptions.port, listenOptions.host)
+    var redisOut = listenOptions.url?Redis.createClient(listenOptions):Redis.createClient(listenOptions.port, listenOptions.host)
 
     handleEvents(redisIn)
     handleEvents(redisOut)
@@ -91,8 +91,8 @@ module.exports = function (options) {
 
     tu.make_client(makeSend, clientOptions, clientdone)
 
-    redisIn = Redis.createClient(clientOptions.port, clientOptions.host)
-    redisOut = Redis.createClient(clientOptions.port, clientOptions.host)
+    redisIn = clientOptions.url?Redis.createClient(clientOptions):Redis.createClient(clientOptions.port, clientOptions.host)
+    redisOut = clientOptions.url?Redis.createClient(clientOptions):Redis.createClient(clientOptions.port, clientOptions.host)
 
     handleEvents(redisIn)
     handleEvents(redisOut)

--- a/redis-queue-transport.js
+++ b/redis-queue-transport.js
@@ -35,8 +35,8 @@ module.exports = function (options) {
     var type = args.type
     var listenOptions = seneca.util.clean(_.extend({}, options[type], args))
     var useTopic = args.topic || 'seneca_any'
-      var redisIn = listenOptions.url?Redis.createClient(listenOptions):Redis.createClient(listenOptions.port, listenOptions.host)
-    var redisOut = listenOptions.url?Redis.createClient(listenOptions):Redis.createClient(listenOptions.port, listenOptions.host)
+    var redisIn = listenOptions.url ? Redis.createClient(listenOptions) : Redis.createClient(listenOptions.port, listenOptions.host)
+    var redisOut = listenOptions.url ? Redis.createClient(listenOptions) : Redis.createClient(listenOptions.port, listenOptions.host)
 
     handleEvents(redisIn)
     handleEvents(redisOut)
@@ -91,8 +91,8 @@ module.exports = function (options) {
 
     tu.make_client(makeSend, clientOptions, clientdone)
 
-    redisIn = clientOptions.url?Redis.createClient(clientOptions):Redis.createClient(clientOptions.port, clientOptions.host)
-    redisOut = clientOptions.url?Redis.createClient(clientOptions):Redis.createClient(clientOptions.port, clientOptions.host)
+    redisIn = clientOptions.url ? Redis.createClient(clientOptions) : Redis.createClient(clientOptions.port, clientOptions.host)
+    redisOut = clientOptions.url ? Redis.createClient(clientOptions) : Redis.createClient(clientOptions.port, clientOptions.host)
 
     handleEvents(redisIn)
     handleEvents(redisOut)

--- a/test/bad.brpop.test.js
+++ b/test/bad.brpop.test.js
@@ -8,6 +8,7 @@ var _ = require('lodash')
 
 var RedisQueueTransport = require('../redis-queue-transport.js')
 var DefaultConfig = require('./default_config.json')
+var RedisUrlConfig = require('./redis_url_config.json')
 
 // Test shortcuts
 var lab = exports.lab = Lab.script()
@@ -20,6 +21,7 @@ var internals = {
   }
 }
 _.assign(internals.defaults['redis-queue'], DefaultConfig)
+_.assign(internals.defaults['redis-queue'], RedisUrlConfig)
 
 var brpop = require('redis').RedisClient.prototype.brpop
 

--- a/test/bad.lpush.test.js
+++ b/test/bad.lpush.test.js
@@ -8,6 +8,7 @@ var _ = require('lodash')
 
 var RedisQueueTransport = require('../redis-queue-transport.js')
 var DefaultConfig = require('./default_config.json')
+var RedisUrlConfig = require('./redis_url_config.json')
 
 // Test shortcuts
 var lab = exports.lab = Lab.script()
@@ -20,6 +21,7 @@ var internals = {
   }
 }
 _.assign(internals.defaults['redis-queue'], DefaultConfig)
+_.assign(internals.defaults['redis-queue'], RedisUrlConfig)
 
 var lpush = require('redis').RedisClient.prototype.lpush
 

--- a/test/redis_url_config.json
+++ b/test/redis_url_config.json
@@ -1,0 +1,5 @@
+{
+  "type": "redis-queue",
+  "url": "redis://localhost:6379",
+  "options": { }
+}


### PR DESCRIPTION
Redis URLS that contain authentication was impossible to use (including heroku URLs in form: `REDIS_URL=redis://h:p623c87ba8c5be00fe5a3add69820632c473dde389a9a608a1167c8dc03d92f05@ec2-52-225-231-45.compute-2.amazonaws.com:25899`)

Now it's possible through supplying credentials in `options.url`:

```
        .use('redis-queue-transport', {                                                                                                                                                                                                                                                                                       
            'redis-queue': {                                                                                                                                                                                                                                                                                                  
                timeout: 3000,                                                                                                                                                                                                                                                                                                
                type: 'redis-queue',                                                                                                                                                                                                                                                                                          
                url: 'redis://login:password@some_redis_server:25899'                                                                                                                                                                                                                                                                                               
            }                                                                                                                                                                                                                                                                                                                 
        })   
```